### PR TITLE
Scale and smear2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # heavyNeutrino
 New repository for Ghent CMS analysis tuplizer framework (initially created for heavy neutrino analysis).
-In order to have a working copy, one needs to set up the CMSSW release as instructed below. For CMSSW\_8, the ./setup.sh script downloads some needed additional packages.
+In order to have a working copy, one needs to set up the CMSSW release as instructed below. The ./setup.sh script switches to the preferred branch and downloads the needed additional packages.
 The tuplizer itself is entirely contained in the multilep directory.
 
-# Set-up instructions
+# Set-up instructions for 2016 data
+```
+cmsrel CMSSW_8_0_30
+cd CMSSW_8_0_30/src
+cmsenv
+git cms-init
+git clone https://github.com/GhentAnalysis/heavyNeutrino
+cd heavyNeutrino
+./setup.sh
+```
+
+# Set-up instructions for 2017 data
 ```
 cmsrel CMSSW_9_4_3
 cd CMSSW_9_4_3/src
@@ -13,7 +24,6 @@ git clone https://github.com/GhentAnalysis/heavyNeutrino
 cd heavyNeutrino
 ./setup.sh
 ```
-
 
 # Running a test job
 ```

--- a/multilep/interface/GenAnalyzer.h
+++ b/multilep/interface/GenAnalyzer.h
@@ -57,13 +57,14 @@ class GenAnalyzer {
     unsigned ttgEventType(const std::vector<reco::GenParticle>& genParticles, double ptCut, double etaCut) const;
     double   getMinDeltaR(const reco::GenParticle& p, const std::vector<reco::GenParticle>& genParticles) const;
 
+    TH1I*     eventTypes;
     multilep* multilepAnalyzer;
 
   public:
     GenAnalyzer(const edm::ParameterSet& iConfig, multilep* vars);
     ~GenAnalyzer(){};
 
-    void beginJob(TTree* outputTree);
+    void beginJob(TTree* outputTree, edm::Service<TFileService>& fs);
     void analyze(const edm::Event&);
 };
 #endif

--- a/multilep/interface/LeptonAnalyzer.h
+++ b/multilep/interface/LeptonAnalyzer.h
@@ -49,10 +49,20 @@ class LeptonAnalyzer {
     unsigned _nTau;
 
     double _lPt[nL_max];                                                                             //lepton kinematics
+    double _lPtCorr[nL_max];
+    double _lPtScaleUp[nL_max];
+    double _lPtScaleDown[nL_max];
+    double _lPtResUp[nL_max];
+    double _lPtResDown[nL_max];
     double _lEta[nL_max];
     double _lEtaSC[nL_max];
     double _lPhi[nL_max];
     double _lE[nL_max];
+    double _lECorr[nL_max];
+    double _lEScaleUp[nL_max];
+    double _lEScaleDown[nL_max];
+    double _lEResUp[nL_max];
+    double _lEResDown[nL_max];
 
     unsigned _lFlavor[nL_max];                                                                       //lepton flavor and charge
     int _lCharge[nL_max];

--- a/multilep/interface/PhotonAnalyzer.h
+++ b/multilep/interface/PhotonAnalyzer.h
@@ -23,10 +23,20 @@ class PhotonAnalyzer {
 
         unsigned _nPh;
         double   _phPt[nPhoton_max];
+        double   _phPtCorr[nPhoton_max];
+        double   _phPtScaleUp[nPhoton_max];
+        double   _phPtScaleDown[nPhoton_max];
+        double   _phPtResUp[nPhoton_max];
+        double   _phPtResDown[nPhoton_max];
         double   _phEta[nPhoton_max];
         double   _phEtaSC[nPhoton_max];
         double   _phPhi[nPhoton_max];
         double   _phE[nPhoton_max];
+        double   _phECorr[nPhoton_max];
+        double   _phEScaleUp[nPhoton_max];
+        double   _phEScaleDown[nPhoton_max];
+        double   _phEResUp[nPhoton_max];
+        double   _phEResDown[nPhoton_max];
         bool     _phCutBasedLoose[nPhoton_max];
         bool     _phCutBasedMedium[nPhoton_max];
         bool     _phCutBasedTight[nPhoton_max];

--- a/multilep/plugins/multilep.h
+++ b/multilep/plugins/multilep.h
@@ -77,6 +77,7 @@ class multilep : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks, ed
         edm::EDGetTokenT<reco::GenParticleCollection>       genParticleToken; 
         edm::EDGetTokenT<std::vector<pat::Muon>>            muonToken;
         edm::EDGetTokenT<std::vector<pat::Electron>>        eleToken;
+        edm::EDGetTokenT<std::vector<pat::Electron>>        eleCalibratedToken;
         edm::EDGetTokenT<edm::ValueMap<float>>              eleMvaToken;
         edm::EDGetTokenT<edm::ValueMap<float>>              eleMvaHZZToken;
         edm::EDGetTokenT<edm::ValueMap<float>>              eleMvaFall17IsoToken;
@@ -87,6 +88,7 @@ class multilep : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks, ed
         edm::EDGetTokenT<edm::ValueMap<bool>>               eleCutBasedTightToken;
         edm::EDGetTokenT<std::vector<pat::Tau>>             tauToken;
         edm::EDGetTokenT<std::vector<pat::Photon>>          photonToken;
+        edm::EDGetTokenT<std::vector<pat::Photon>>          photonCalibratedToken;
         edm::EDGetTokenT<edm::ValueMap<bool>>               photonCutBasedLooseToken;
         edm::EDGetTokenT<edm::ValueMap<bool>>               photonCutBasedMediumToken;
         edm::EDGetTokenT<edm::ValueMap<bool>>               photonCutBasedTightToken;
@@ -111,6 +113,14 @@ class multilep : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks, ed
         bool                                                isData;
         bool                                                is2017;
         bool                                                isSUSY;
+        edm::EDGetTokenT<edm::ValueMap<float>>              eScaleUpUncertaintyToken;
+        edm::EDGetTokenT<edm::ValueMap<float>>              eScaleDownUncertaintyToken;
+        edm::EDGetTokenT<edm::ValueMap<float>>              eResolutionUpUncertaintyToken;
+        edm::EDGetTokenT<edm::ValueMap<float>>              eResolutionDownUncertaintyToken;
+        edm::EDGetTokenT<edm::ValueMap<float>>              phScaleUpUncertaintyToken;
+        edm::EDGetTokenT<edm::ValueMap<float>>              phScaleDownUncertaintyToken;
+        edm::EDGetTokenT<edm::ValueMap<float>>              phResolutionUpUncertaintyToken;
+        edm::EDGetTokenT<edm::ValueMap<float>>              phResolutionDownUncertaintyToken;
 
         virtual void beginJob() override;
         virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;

--- a/multilep/python/egmSequence_cff.py
+++ b/multilep/python/egmSequence_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
-def addElectronAndPhotonSequence(process, isData):
+def addElectronAndPhotonSequence(process, isData, is2017):
   #
   # EGM Regression
   #
@@ -21,7 +21,7 @@ def addElectronAndPhotonSequence(process, isData):
   process.load('EgammaAnalysis.ElectronTools.calibratedPatElectronsRun2_cfi')
   process.load('EgammaAnalysis.ElectronTools.calibratedPatPhotonsRun2_cfi')
   for calmod in [process.calibratedPatElectrons, process.calibratedPatPhotons]:
-    calmod.correctionFile = cms.string(files['Moriond17_23Jan'])
+    calmod.correctionFile = cms.string(files['Run2017_17Nov2017_v1' if is2017 else 'Moriond17_23Jan'])
     calmod.isMC           = cms.bool(not isData)
 
   #

--- a/multilep/python/egmSequence_cff.py
+++ b/multilep/python/egmSequence_cff.py
@@ -2,12 +2,6 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
 def addElectronAndPhotonSequence(process, isData, is2017):
-  #
-  # EGM Regression
-  #
-  from EgammaAnalysis.ElectronTools.regressionWeights_cfi import regressionWeights
-  process = regressionWeights(process)
-  process.load('EgammaAnalysis.ElectronTools.regressionApplication_cff')
 
   #
   # EGM scale corrections (on data) and smearing (on MC)
@@ -46,4 +40,4 @@ def addElectronAndPhotonSequence(process, isData, is2017):
   process.photonIDValueMapProducer.srcMiniAOD    = cms.InputTag('slimmedPhotons')
   process.photonMVAValueMapProducer.srcMiniAOD   = cms.InputTag('slimmedPhotons')
 
-  process.egmSequence = cms.Sequence(process.regressionApplication * process.calibratedPatElectrons * process.calibratedPatPhotons * process.egmGsfElectronIDSequence * process.egmPhotonIDSequence)
+  process.egmSequence = cms.Sequence(process.calibratedPatElectrons * process.calibratedPatPhotons * process.egmGsfElectronIDSequence * process.egmPhotonIDSequence)

--- a/multilep/python/egmSequence_cff.py
+++ b/multilep/python/egmSequence_cff.py
@@ -1,7 +1,28 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
-def addElectronAndPhotonSequence(process):
+def addElectronAndPhotonSequence(process, isData):
+  #
+  # EGM Regression
+  #
+  from EgammaAnalysis.ElectronTools.regressionWeights_cfi import regressionWeights
+  process = regressionWeights(process)
+  process.load('EgammaAnalysis.ElectronTools.regressionApplication_cff')
+
+  #
+  # EGM scale corrections (on data) and smearing (on MC)
+  #
+  from EgammaAnalysis.ElectronTools.calibrationTablesRun2 import files
+  process.load('Configuration.StandardSequences.Services_cff')
+  process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    calibratedPatElectrons  = cms.PSet( initialSeed = cms.untracked.uint32(81), engineName = cms.untracked.string('TRandom3'),),
+    calibratedPatPhotons    = cms.PSet( initialSeed = cms.untracked.uint32(81), engineName = cms.untracked.string('TRandom3'),),
+  )
+  process.load('EgammaAnalysis.ElectronTools.calibratedPatElectronsRun2_cfi')
+  process.load('EgammaAnalysis.ElectronTools.calibratedPatPhotonsRun2_cfi')
+  for calmod in [process.calibratedPatElectrons, process.calibratedPatPhotons]:
+    calmod.correctionFile = cms.string(files['Moriond17_23Jan'])
+    calmod.isMC           = cms.bool(not isData)
 
   #
   # Set up electron and photon identifications
@@ -18,4 +39,11 @@ def addElectronAndPhotonSequence(process):
                      'RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring16_V2p2_cff']
   for idmod in electronModules: setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
   for idmod in photonModules:   setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
-  process.egmSequence = cms.Sequence(process.egmGsfElectronIDSequence * process.egmPhotonIDSequence)
+
+  process.load("RecoEgamma.ElectronIdentification.ElectronIDValueMapProducer_cfi")
+  process.electronIDValueMapProducer.srcMiniAOD  = cms.InputTag('slimmedElectrons')
+  process.electronMVAValueMapProducer.srcMiniAOD = cms.InputTag('slimmedElectrons')
+  process.photonIDValueMapProducer.srcMiniAOD    = cms.InputTag('slimmedPhotons')
+  process.photonMVAValueMapProducer.srcMiniAOD   = cms.InputTag('slimmedPhotons')
+
+  process.egmSequence = cms.Sequence(process.regressionApplication * process.calibratedPatElectrons * process.calibratedPatPhotons * process.egmGsfElectronIDSequence * process.egmPhotonIDSequence)

--- a/multilep/src/GenTools.cc
+++ b/multilep/src/GenTools.cc
@@ -172,10 +172,10 @@ bool GenTools::isPrompt(const reco::GenParticle& gen, const std::vector<reco::Ge
 double GenTools::getMinDeltaR(const reco::GenParticle& p, const std::vector<reco::GenParticle>& genParticles){
     double minDeltaR = 10;
     for(auto& q : genParticles){
-        if(q.pt() < 5)                                            continue;
-        if(p.pt()-q.pt() < 0.0001)                                continue; // same particle
-        if(q.status() != 1)                                       continue;
-        if(q.pdgId() == 12 or q.pdgId() == 14 or q.pdgId() == 16) continue;
+        if(q.pt() < 5)                                                           continue;
+        if(fabs(p.pt()-q.pt()) < 0.0001)                                         continue; // same particle
+        if(q.status() != 1)                                                      continue;
+        if(abs(q.pdgId()) == 12 or abs(q.pdgId()) == 14 or abs(q.pdgId()) == 16) continue;
         minDeltaR = std::min(minDeltaR, deltaR(p.eta(), p.phi(), q.eta(), q.phi()));
     }
     return minDeltaR;

--- a/multilep/test/multilep.py
+++ b/multilep/test/multilep.py
@@ -8,9 +8,9 @@ def getJSON(is2017):
 
 # Default arguments
 #inputFile       = '/store/mc/RunIISummer16MiniAODv2/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/00A9113F-15D6-E611-9142-047D7B881D3A.root'
-#inputFile       = '/store/mc/RunIISummer16MiniAODv2/TTGamma_Dilept_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/90000/003658EE-77E6-E611-ACB1-7CD30ABD295A.root'
+inputFile       = '/store/mc/RunIISummer16MiniAODv2/TTGamma_Dilept_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/90000/003658EE-77E6-E611-ACB1-7CD30ABD295A.root'
 #inputFile       = '/store/data/Run2016D/DoubleMuon/MINIAOD/03Feb2017-v1/100000/52779EE0-F4ED-E611-BF87-70106F49CD3C.root'
-inputFile       = "root://cmsxrootd.fnal.gov///store/data/Run2017C/MuonEG/MINIAOD/PromptReco-v3/000/300/780/00000/86494C82-EA7E-E711-ACCC-02163E01441B.root"
+#inputFile       = "root://cmsxrootd.fnal.gov///store/data/Run2017C/MuonEG/MINIAOD/PromptReco-v3/000/300/780/00000/86494C82-EA7E-E711-ACCC-02163E01441B.root"
 #inputFile       = 'file:///pnfs/iihe/cms/store/user/tomc/heavyNeutrinoMiniAOD/prompt/HeavyNeutrino_trilepton_M-100_V-0.01_2l_NLO/heavyNeutrino_1.root'
 #inputFile       = "root://xrootd-cms.infn.it///store/mc/RunIISummer16MiniAODv2/SMS-TChiWZ_ZToLL_mZMin-0p1_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSummer16Fast_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/18589842-DCBD-E611-B8BF-0025905A48D8.root"
 nEvents         = 1000
@@ -67,7 +67,7 @@ process.goodOfflinePrimaryVertices.filter = cms.bool(False)                     
 from heavyNeutrino.multilep.jetSequence_cff import addJetSequence
 from heavyNeutrino.multilep.egmSequence_cff import addElectronAndPhotonSequence
 addJetSequence(process, isData)
-addElectronAndPhotonSequence(process)
+addElectronAndPhotonSequence(process, isData)
 
 #
 # Read additional MET filters not stored in miniAOD
@@ -93,6 +93,11 @@ process.blackJackAndHookers = cms.EDAnalyzer('multilep',
   muonsEffectiveAreas           = cms.FileInPath('heavyNeutrino/multilep/data/effAreaMuons_cone03_pfNeuHadronsAndPhotons_80X.txt'),
   muonsEffectiveAreasFall17     = cms.FileInPath('heavyNeutrino/multilep/data/effAreas_cone03_Muons_Fall17.txt'),
   electrons                     = cms.InputTag("slimmedElectrons"),
+  electronsCalibrated           = cms.InputTag("calibratedPatElectrons"),
+  eScaleUpUncertainty           = cms.InputTag('calibratedPatElectrons:EGMscaleUpUncertainty'),
+  eScaleDownUncertainty         = cms.InputTag('calibratedPatElectrons:EGMscaleDownUncertainty'),
+  eResolutionUpUncertainty      = cms.InputTag('calibratedPatElectrons:EGMresolutionUpUncertainty'),
+  eResolutionDownUncertainty    = cms.InputTag('calibratedPatElectrons:EGMresolutionDownUncertainty'),
   electronsEffectiveAreas       = cms.FileInPath('RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_25ns.txt'), # WARNING this is spring 15, following SUSY-standard, i.e. not the most up-to-date values
   electronsEffectiveAreasFall17 = cms.FileInPath('RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt'),
 
@@ -109,6 +114,11 @@ process.blackJackAndHookers = cms.EDAnalyzer('multilep',
   leptonMvaWeightsMuttH         = cms.FileInPath("heavyNeutrino/multilep/data/mvaWeights/mu_ttH_BDTG.weights.xml"),
   leptonMvaWeightsElettH        = cms.FileInPath("heavyNeutrino/multilep/data/mvaWeights/el_ttH_BDTG.weights.xml"),   
   photons                       = cms.InputTag("slimmedPhotons"),
+  photonsCalibrated             = cms.InputTag("calibratedPatPhotons"),
+  phScaleUpUncertainty          = cms.InputTag('calibratedPatPhotons:EGMscaleUpUncertainty'),
+  phScaleDownUncertainty        = cms.InputTag('calibratedPatPhotons:EGMscaleDownUncertainty'),
+  phResolutionUpUncertainty     = cms.InputTag('calibratedPatPhotons:EGMresolutionUpUncertainty'),
+  phResolutionDownUncertainty   = cms.InputTag('calibratedPatPhotons:EGMresolutionDownUncertainty'),
   photonsChargedEffectiveAreas  = cms.FileInPath('RecoEgamma/PhotonIdentification/data/Spring16/effAreaPhotons_cone03_pfChargedHadrons_90percentBased.txt'),
   photonsNeutralEffectiveAreas  = cms.FileInPath('RecoEgamma/PhotonIdentification/data/Spring16/effAreaPhotons_cone03_pfNeutralHadrons_90percentBased.txt'),
   photonsPhotonsEffectiveAreas  = cms.FileInPath('RecoEgamma/PhotonIdentification/data/Spring16/effAreaPhotons_cone03_pfPhotons_90percentBased.txt'),
@@ -137,7 +147,7 @@ process.blackJackAndHookers = cms.EDAnalyzer('multilep',
   skim                          = cms.untracked.string(outputFile.split('/')[-1].split('.')[0].split('_')[0]),
   isData                        = cms.untracked.bool(isData),
   is2017                        = cms.untracked.bool(is2017),
-  isSUSY                        = cms.untracked.bool(isSUSY)
+  isSUSY                        = cms.untracked.bool(isSUSY),
 )
 
 if isData:

--- a/multilep/test/multilep.py
+++ b/multilep/test/multilep.py
@@ -67,7 +67,7 @@ process.goodOfflinePrimaryVertices.filter = cms.bool(False)                     
 from heavyNeutrino.multilep.jetSequence_cff import addJetSequence
 from heavyNeutrino.multilep.egmSequence_cff import addElectronAndPhotonSequence
 addJetSequence(process, isData)
-addElectronAndPhotonSequence(process, isData)
+addElectronAndPhotonSequence(process, isData, is2017)
 
 #
 # Read additional MET filters not stored in miniAOD

--- a/multilep/test/multilep.py
+++ b/multilep/test/multilep.py
@@ -8,9 +8,9 @@ def getJSON(is2017):
 
 # Default arguments
 #inputFile       = '/store/mc/RunIISummer16MiniAODv2/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/00A9113F-15D6-E611-9142-047D7B881D3A.root'
-inputFile       = '/store/mc/RunIISummer16MiniAODv2/TTGamma_Dilept_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/90000/003658EE-77E6-E611-ACB1-7CD30ABD295A.root'
+#inputFile       = '/store/mc/RunIISummer16MiniAODv2/TTGamma_Dilept_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/90000/003658EE-77E6-E611-ACB1-7CD30ABD295A.root'
 #inputFile       = '/store/data/Run2016D/DoubleMuon/MINIAOD/03Feb2017-v1/100000/52779EE0-F4ED-E611-BF87-70106F49CD3C.root'
-#inputFile       = "root://cmsxrootd.fnal.gov///store/data/Run2017C/MuonEG/MINIAOD/PromptReco-v3/000/300/780/00000/86494C82-EA7E-E711-ACCC-02163E01441B.root"
+inputFile       = "root://cmsxrootd.fnal.gov///store/data/Run2017C/MuonEG/MINIAOD/PromptReco-v3/000/300/780/00000/86494C82-EA7E-E711-ACCC-02163E01441B.root"
 #inputFile       = 'file:///pnfs/iihe/cms/store/user/tomc/heavyNeutrinoMiniAOD/prompt/HeavyNeutrino_trilepton_M-100_V-0.01_2l_NLO/heavyNeutrino_1.root'
 #inputFile       = "root://xrootd-cms.infn.it///store/mc/RunIISummer16MiniAODv2/SMS-TChiWZ_ZToLL_mZMin-0p1_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSummer16Fast_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/18589842-DCBD-E611-B8BF-0025905A48D8.root"
 nEvents         = 1000

--- a/multilep/test/multilep.py
+++ b/multilep/test/multilep.py
@@ -8,9 +8,9 @@ def getJSON(is2017):
 
 # Default arguments
 #inputFile       = '/store/mc/RunIISummer16MiniAODv2/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/00A9113F-15D6-E611-9142-047D7B881D3A.root'
-#inputFile       = '/store/mc/RunIISummer16MiniAODv2/TTGamma_Dilept_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/90000/003658EE-77E6-E611-ACB1-7CD30ABD295A.root'
+inputFile       = '/store/mc/RunIISummer16MiniAODv2/TTGamma_Dilept_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/90000/003658EE-77E6-E611-ACB1-7CD30ABD295A.root'
 #inputFile       = '/store/data/Run2016D/DoubleMuon/MINIAOD/03Feb2017-v1/100000/52779EE0-F4ED-E611-BF87-70106F49CD3C.root'
-inputFile       = "root://cmsxrootd.fnal.gov///store/data/Run2017C/MuonEG/MINIAOD/PromptReco-v3/000/300/780/00000/86494C82-EA7E-E711-ACCC-02163E01441B.root"
+#inputFile       = "root://cmsxrootd.fnal.gov///store/data/Run2017C/MuonEG/MINIAOD/PromptReco-v3/000/300/780/00000/86494C82-EA7E-E711-ACCC-02163E01441B.root"
 #inputFile       = 'file:///pnfs/iihe/cms/store/user/tomc/heavyNeutrinoMiniAOD/prompt/HeavyNeutrino_trilepton_M-100_V-0.01_2l_NLO/heavyNeutrino_1.root'
 #inputFile       = "root://xrootd-cms.infn.it///store/mc/RunIISummer16MiniAODv2/SMS-TChiWZ_ZToLL_mZMin-0p1_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSummer16Fast_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/18589842-DCBD-E611-B8BF-0025905A48D8.root"
 nEvents         = 1000

--- a/setup.sh
+++ b/setup.sh
@@ -5,11 +5,11 @@ then
   eval `scram runtime -sh`
   cd $CMSSW_BASE/src
 
-  # EGM smearing
+  # First EGM smearing
   git cms-merge-topic cms-egamma:EGM_gain_v1
   cd EgammaAnalysis/ElectronTools/data
   git clone -b Moriond17_gainSwitch_unc https://github.com/ECALELFS/ScalesSmearings.git 
-  cd $CMSSW_BASE/src
+  cd -
 
   # Setup for new electron and photon MVA
   git cms-merge-topic ikrav:egm_id_80X_v3_photons

--- a/setup.sh
+++ b/setup.sh
@@ -18,9 +18,17 @@ else
   # CMSSW_9_4_X checkout
   eval `scram runtime -sh`
   cd $CMSSW_BASE/src
+
+  # First EGM smearing
+  git cms-merge-topic cms-egamma:EGM_94X_v1
+  cd EgammaAnalysis/ElectronTools/data
+  git clone https://github.com/ECALELFS/ScalesSmearings.git
+  cd ScalesSmearings/
+  git checkout Run2017_17Nov2017_v1
+
+  # Electron ID
   git cms-merge-topic lsoffi:CMSSW_9_4_0_pre3_TnP
   git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
-  scram b -j 10
 
   # Setting up new photon ID
   cd $CMSSW_BASE/external
@@ -34,14 +42,6 @@ else
   cd data/RecoEgamma/ElectronIdentification/data
   git checkout CMSSW_9_4_0_pre3_TnP
   cd $CMSSW_BASE/src
-
-  # EGM smearing
-  git cms-merge-topic cms-egamma:EGM_94X_v1
-  cd EgammaAnalysis/ElectronTools/data
-  git clone https://github.com/ECALELFS/ScalesSmearings.git
-  cd ScalesSmearings/
-  git checkout Run2017_17Nov2017_v1
-
 fi
 
 # Finally, compile

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,7 @@ else
   eval `scram runtime -sh`
   cd $CMSSW_BASE/src
   git cms-merge-topic lsoffi:CMSSW_9_4_0_pre3_TnP
+  git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
   scram b -j 10
 
   # Setting up new photon ID

--- a/setup.sh
+++ b/setup.sh
@@ -33,6 +33,14 @@ else
   cd data/RecoEgamma/ElectronIdentification/data
   git checkout CMSSW_9_4_0_pre3_TnP
   cd $CMSSW_BASE/src
+
+  # EGM smearing
+  git cms-merge-topic cms-egamma:EGM_94X_v1
+  cd EgammaAnalysis/ElectronTools/data
+  git clone https://github.com/ECALELFS/ScalesSmearings.git
+  cd ScalesSmearings/
+  git checkout Run2017_17Nov2017_v1
+
 fi
 
 # Finally, compile

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,7 @@ else
   # Electron ID
   git cms-merge-topic lsoffi:CMSSW_9_4_0_pre3_TnP
   git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
+  scram b -j 10
 
   # Setting up new photon ID
   cd $CMSSW_BASE/external


### PR DESCRIPTION
Based on merging the CMSSW_8_X_0 branch, a working version of the master branch for 2017 data in CMSSW_9_X_0. Open issues:
- Does not work yet for miniAOD samples processed in Summer16, when the regression was not yet included in miniAOD. But the needed code to derive the regression for Summer16 is not part anymore of CMSSW_9.
- Should still be checked if the values in the output tuples are ok