### PR TITLE
Bug fix: make sure we always skim on nVertices=0, even when ParticleL…

### DIFF
--- a/multilep/plugins/multilep.cc
+++ b/multilep/plugins/multilep.cc
@@ -119,7 +119,7 @@ void multilep::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup){
     if( isMC() && storeParticleLevel ) applySkim = !particleLevelAnalyzer->analyze(iEvent);
     else applySkim = true;
 
-    if(_nVertex == 0 and applySkim)                                          return;          // Don't consider 0 vertex events
+    if(_nVertex == 0)                                                        return;          // Don't consider 0 vertex events
     if(!leptonAnalyzer->analyze(iEvent, *(vertices->begin())) and applySkim) return;          // returns false if doesn't pass applySkim condition, so skip event in such case
     if(!photonAnalyzer->analyze(iEvent) and applySkim)                       return;
     if(!jetAnalyzer->analyze(iEvent) and applySkim)                          return;


### PR DESCRIPTION
…evel is passed