### PR TITLE
updated ZgEventType gencone size

### DIFF
--- a/multilep/interface/GenAnalyzer.h
+++ b/multilep/interface/GenAnalyzer.h
@@ -47,7 +47,7 @@ class GenAnalyzer {
     bool     _gen_lPassParentage[gen_nL_max];
     double   _gen_lMinDeltaR[gen_nL_max];
 
-    unsigned overlapEventType(const std::vector<reco::GenParticle>& genParticles, double ptCut, double etaCut) const;
+    unsigned overlapEventType(const std::vector<reco::GenParticle>& genParticles, double ptCut, double etaCut, double genCone) const;
     double   getMinDeltaR(const reco::GenParticle& p, const std::vector<reco::GenParticle>& genParticles) const;
 
     multilep* multilepAnalyzer;

--- a/multilep/src/GenAnalyzer.cc
+++ b/multilep/src/GenAnalyzer.cc
@@ -52,8 +52,8 @@ void GenAnalyzer::analyze(const edm::Event& iEvent){
     if(!genParticles.isValid()) return;
 
     // TODO: when applying overlap for new photon samples: check the pt and eta cuts of the photon
-    _ttgEventType = overlapEventType(*genParticles, 10., 5.0); // for TTGamma_Dilept_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8
-    _zgEventType  = overlapEventType(*genParticles, 15., 2.6); // for ZGToLLG_01J_5f_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8
+    _ttgEventType = overlapEventType(*genParticles, 10., 5.0, 0.1);
+    _zgEventType  = overlapEventType(*genParticles, 15., 2.6, 0.05);
 
     _gen_nL = 0;
     _gen_nPh = 0;
@@ -117,7 +117,7 @@ void GenAnalyzer::analyze(const edm::Event& iEvent){
 /*
  * Some event categorization in order to understand/debug/apply overlap removal for TTGamma <--> TTJets and similar photon samples
  */
-unsigned GenAnalyzer::overlapEventType(const std::vector<reco::GenParticle>& genParticles, double ptCut, double etaCut) const{
+unsigned GenAnalyzer::overlapEventType(const std::vector<reco::GenParticle>& genParticles, double ptCut, double etaCut, double genCone) const{
     int type = 0;
     for(auto p = genParticles.cbegin(); p != genParticles.cend(); ++p){
         if(p->status()<0)         continue;
@@ -127,7 +127,7 @@ unsigned GenAnalyzer::overlapEventType(const std::vector<reco::GenParticle>& gen
         if(fabs(p->eta())>etaCut) continue;
         type = std::max(type, 2);                                                            // Type 2: photon from pion or other meson
 
-        if(GenTools::getMinDeltaR(*p, genParticles) < 0.1) continue;
+        if(GenTools::getMinDeltaR(*p, genParticles) < genCone) continue;
         if(not GenTools::passParentage(*p, genParticles))  continue;
 
         // Everything below is *signal*


### PR DESCRIPTION
only relevant for ttgamma, change based on the following mail:

Hi everyone,
as discussed in the meeting, we should take care about the settings for the overlap removal:

for the new ttgamma samples we should use pTgamma cuts of 10 GeV and eta(gamma) cuts of 5.0 (as in the run card):
https://github.com/cms-sw/genproductions/blob/master/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ttGamma_Dilept_5f_ckm_LO_1line/ttGamma_Dilept_5f_ckm_LO_1line_run_card.dat#L107


Also, I think we have a wrong cone-size for our overlap removal in Zgamma and Wgamma:
We currently check the iso-criteria for gen-particles in a cone size of 0.2, but the run-card for WGamma and ZGamma uses 0.05 (are these the right run cards?):

https://github.com/cms-sw/genproductions/blob/mg261/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WAToLNuA01j_5f_NLO_FXFX/WAToLNuA01j_5f_NLO_FXFX_run_card.dat#L140-L142
https://github.com/cms-sw/genproductions/blob/mg261/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZATo2LA01j_5f_NLO_FXFX/ZATo2LA01j_5f_NLO_FXFX_run_card.dat#L139-L141

The same is true for the TGamma overlap removal.

All in all i currently use these settings for the overlap removal:

ttgamma/ttbar:
pT cut: 10 GeV
eta cut: 5.0
gen-cone size: deltaR = 0.1
gen-pT > 5 GeV

ZGamma/DY and WGamma/WJets:
pT cut: 15 GeV
eta cut: 2.6
gen-cone size: deltaR = 0.05
gen-pT > 5 GeV

TGamma/Single-top t-channel:
pT cut: 10 GeV
eta cut: 2.6
gen-cone size: deltaR = 0.05
gen-pT > 5 GeV

Also I added gamma+jets samples to the QCD samples with

GJets/QCD:
pT cut: 25 GeV
eta cut: 2.5
gen-cone size: deltaR = 0.4
gen-pT > 5 GeV

Any thoughts?

Best,
Lukas

