### PR TITLE
Adding a dilepton filter, to run before all other modules

### DIFF
--- a/multilep/plugins/multilepFilter.cc
+++ b/multilep/plugins/multilepFilter.cc
@@ -1,0 +1,104 @@
+#include "heavyNeutrino/multilep/plugins/multilepFilter.h"
+#include "heavyNeutrino/multilep/interface/Header.h"
+
+
+multilepFilter::multilepFilter(const edm::ParameterSet& iConfig):
+    vtxToken(                 consumes<std::vector<reco::Vertex>>(             iConfig.getParameter<edm::InputTag>("vertices"))),
+    muonToken(                consumes<std::vector<pat::Muon>>(                iConfig.getParameter<edm::InputTag>("muons"))),
+    eleToken(                 consumes<std::vector<pat::Electron>>(            iConfig.getParameter<edm::InputTag>("electrons"))),
+    triggerToken(             consumes<edm::TriggerResults>(                   iConfig.getParameter<edm::InputTag>("triggers"))),
+    trigObjToken(             consumes<pat::TriggerObjectStandAloneCollection>(iConfig.getParameter<edm::InputTag>("triggerObjects"))),
+    sampleIs2017(                                                              iConfig.getUntrackedParameter<bool>("is2017")),
+    sampleIs2018(                                                              iConfig.getUntrackedParameter<bool>("is2018"))
+{
+}
+
+// Some quick code duplication form TriggerAnalyzer here...
+std::vector<const pat::TriggerObjectStandAlone*> multilepFilter::getMatchedObjects(const pat::Electron& ele, const std::vector<pat::TriggerObjectStandAlone>& trigObjs, const float maxDeltaR){
+  std::vector<const pat::TriggerObjectStandAlone*> matchedObjs;
+  const float maxDR2 = maxDeltaR*maxDeltaR;
+  for(auto& trigObj : trigObjs){
+    const float dR2 = reco::deltaR2(ele.superCluster()->eta(), ele.superCluster()->phi(), trigObj.eta(), trigObj.phi());
+    if(dR2<maxDR2) matchedObjs.push_back(&trigObj);
+  }
+  return matchedObjs;
+}
+
+bool multilepFilter::passTrigger(const edm::Event& iEvent, std::string name){
+  auto triggerResults = getHandle(iEvent, triggerToken);
+
+  if(sampleIs2017 and name=="HLT_Ele32_WPTight_Gsf"){
+    // the usual Ele32 emulation for 2017
+    auto triggerObjects = getHandle(iEvent, trigObjToken);
+    std::vector<pat::TriggerObjectStandAlone> unpackedTriggerObjects;
+    for(auto& trigObj : *triggerObjects){
+      unpackedTriggerObjects.push_back(trigObj);
+      unpackedTriggerObjects.back().unpackFilterLabels(iEvent, *triggerResults);
+    }
+
+    auto electrons = getHandle(iEvent, eleToken);
+    for(auto& ele : *electrons){
+      for(const auto trigObj : getMatchedObjects(ele, unpackedTriggerObjects, 0.1)){
+        if(!trigObj->hasFilterLabel("hltEle32L1DoubleEGWPTightGsfTrackIsoFilter")) continue;
+        if(!trigObj->hasFilterLabel("hltEGL1SingleEGOrFilter")) continue;
+        return true;
+      }
+    }
+    return false;
+  } else {
+    const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerResults);
+    for (unsigned i = 0; i < triggerResults->size(); ++i){
+      if(TString(triggerNames.triggerName(i)).Contains(name + "_v")){
+        return triggerResults->accept(i);
+      }
+    }
+    return false;
+  }
+} 
+
+// ------------ method called for each event  ------------
+bool multilepFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup){
+    auto electrons      = getHandle(iEvent, eleToken);
+    auto muons          = getHandle(iEvent, muonToken);
+    auto vertices       = getHandle(iEvent, vtxToken);
+    if(vertices->size() == 0) return false;          // Don't consider 0 vertex events
+
+
+
+    // Trigger
+    std::vector<std::string> triggers;
+    if(sampleIs2018 or sampleIs2017) triggers = {"HLT_Ele32_WPTight_Gsf", "HLT_IsoMu24"};
+    else                             triggers = {"HLT_Ele27_WPTight_Gsf", "HLT_IsoMu24"};
+
+    bool passedTrigger = false;
+    for(auto triggerName : triggers){
+      passedTrigger = passedTrigger or passTrigger(iEvent, triggerName);
+    }
+    if(not passedTrigger) return false;
+
+
+
+    int _nLight = 0;
+    //loop over muons
+    for(const pat::Muon& mu : *muons){
+        if(mu.innerTrack().isNull())                   continue;
+        if(mu.pt() < 5)                                continue;
+        if(fabs(mu.eta()) > 2.4)                       continue;
+        if(!mu.isPFMuon())                             continue;
+        if(!(mu.isTrackerMuon() || mu.isGlobalMuon())) continue;
+        ++_nLight;
+    }
+
+    // Loop over electrons
+    for(auto ele = electrons->begin(); ele != electrons->end(); ++ele){
+        if(ele->gsfTrack().isNull())                   continue;
+        if(ele->pt() < 7)                              continue;
+        if(fabs(ele->eta()) > 2.5)                     continue;
+        ++_nLight;
+    }
+
+    return _nLight >= 2;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(multilepFilter);

--- a/multilep/plugins/multilepFilter.h
+++ b/multilep/plugins/multilepFilter.h
@@ -1,0 +1,50 @@
+#ifndef MULTILEP_H
+#define MULTILEP_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+#include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+
+// Allow for easy way to retrieve handles
+namespace {
+  template<typename T, typename I> edm::Handle<T> getHandle(const I& iEvent,const edm::EDGetTokenT<T>& token){
+    edm::Handle<T> handle;
+    iEvent.getByToken(token,handle);
+    return handle;
+  }
+}
+
+
+class multilepFilter : public edm::one::EDFilter<edm::one::SharedResources> {
+    public:
+        explicit multilepFilter(const edm::ParameterSet&);
+        ~multilepFilter(){};
+
+    private:
+        edm::EDGetTokenT<std::vector<reco::Vertex>>              vtxToken;
+        edm::EDGetTokenT<std::vector<pat::Muon>>                 muonToken;
+        edm::EDGetTokenT<std::vector<pat::Electron>>             eleToken;
+        edm::EDGetTokenT<edm::TriggerResults>                    triggerToken;
+        edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> trigObjToken;
+        bool                                                     sampleIs2017;
+        bool                                                     sampleIs2018;
+
+        std::vector<const pat::TriggerObjectStandAlone*> getMatchedObjects(const pat::Electron& ele, const std::vector<pat::TriggerObjectStandAlone>& trigObjs, const float maxDeltaR);
+        bool passTrigger(const edm::Event& iEvent, std::string name);
+        bool filter(edm::Event&, const edm::EventSetup&) override;
+};
+#endif
+

--- a/multilep/test/multilep.py
+++ b/multilep/test/multilep.py
@@ -206,6 +206,19 @@ process.blackJackAndHookers = cms.EDAnalyzer('multilep',
   headerPart2                   = cms.FileInPath("heavyNeutrino/multilep/data/header/text.txt")
 )
 
+#
+# Additional dilep filter and trigger filter to be run before the IVF in order to avoid running out of walltime
+#
+process.dilepFilter = cms.EDFilter('multilepFilter',
+  vertices                      = cms.InputTag("goodOfflinePrimaryVertices"),
+  muons                         = cms.InputTag("slimmedMuons"),
+  electrons                     = cms.InputTag("slimmedElectrons"),
+  triggers                      = cms.InputTag("TriggerResults::HLT"),
+  triggerObjects                = cms.InputTag("slimmedPatTrigger"),
+  is2017                        = cms.untracked.bool(is2017),
+  is2018                        = cms.untracked.bool(is2018),
+)
+
 def getJSON(is2017, is2018):
     if is2018:   return "Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt"
     elif is2017: return "Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON_v1.txt"
@@ -217,6 +230,7 @@ if isData:
   process.source.lumisToProcess = LumiList.LumiList(filename = os.path.join(jsonDir, getJSON(is2017, is2018))).getVLuminosityBlockRange()
 
 process.p = cms.Path(process.goodOfflinePrimaryVertices *
+                     process.dilepFilter *
                      process.egammaPostRecoSeq *
                      process.jetSequence *
                      process.fullPatMetSequence *


### PR DESCRIPTION
This should drastically reduce the walltime of the jobs:
the IVF will only be run for events which pass the analysis trigger
and loose lepton requirements.