### PR TITLE
Update CMSSW version and l1 prefiring

### DIFF
--- a/multilep/test/multilep.py
+++ b/multilep/test/multilep.py
@@ -57,10 +57,10 @@ process.TFileService = cms.Service("TFileService", fileName = cms.string(outputF
 
 # Latest recommended global tags can always be checked here: https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVAnalysisSummaryTable
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-if is2018:                             process.GlobalTag.globaltag = '106X_dataRun2_v32' if isData else '106X_upgrade2018_realistic_v15_L1v1'
-elif is2017:                             process.GlobalTag.globaltag = '106X_dataRun2_v32' if isData else '106X_mc2017_realistic_v8'
-elif is2016preVFP:                       process.GlobalTag.globaltag = '106X_dataRun2_v32' if isData else '106X_mcRun2_asymptotic_preVFP_v9'
-else:                                    process.GlobalTag.globaltag = '106X_dataRun2_v32' if isData else '106X_mcRun2_asymptotic_v15'
+if is2018:                             process.GlobalTag.globaltag = '106X_dataRun2_v35' if isData else '106X_upgrade2018_realistic_v15_L1v1'
+elif is2017:                             process.GlobalTag.globaltag = '106X_dataRun2_v35' if isData else '106X_mc2017_realistic_v8'
+elif is2016preVFP:                       process.GlobalTag.globaltag = '106X_dataRun2_v35' if isData else '106X_mcRun2_asymptotic_preVFP_v11'
+else:                                    process.GlobalTag.globaltag = '106X_dataRun2_v35' if isData else '106X_mcRun2_asymptotic_v17'
 
 #
 # Vertex collection
@@ -153,13 +153,14 @@ else: setupEgammaPostRecoSeq(process,
 #
 # L1 prefiring (only needed for 2016/2017, use empty sequence for 2018)
 #
-from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+from PhysicsTools.PatUtils.l1PrefiringWeightProducer_cfi import l1PrefiringWeightProducer
 if not is2018:
-  process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
-      DataEra                      = cms.string("2017BtoF" if is2017 else "2016BtoH"),
-      UseJetEMPt                   = cms.bool(False),
-      PrefiringRateSystematicUncty = cms.double(0.2),
-      SkipWarnings                 = False
+  process.prefiringweight = l1PrefiringWeightProducer.clone(
+      DataEraECAL                      = cms.string("2017BtoF" if is2017 else "2016BtoH"),
+      DataEraMuon                      = cms.string("2017BtoF" if is2017 else "2016BtoH"),
+      UseJetEMPt                       = cms.bool(False),
+      PrefiringRateSystematicUnctyECAL = cms.double(0.2),
+      PrefiringRateSystematicUnctyMuon = cms.double(0.2)
   )
 else:
   process.prefiringweight = cms.Sequence()

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,7 @@ BRANCH=UL_master
 # fi
 
 export SCRAM_ARCH=slc7_amd64_gcc820
-RELEASE=CMSSW_10_6_20
+RELEASE=CMSSW_10_6_27
 
 # If the release is already available using cmsenv, use it, otherwise set up a new one
 if [[ $CMSSW_BASE == *$RELEASE ]] && [[ -d $CMSSW_BASE ]]; then


### PR DESCRIPTION
**Changes:**

- Changed CMSSW version to CMSSW_10_6_27 in setup script
- Changed global tags to latest recommendations
- Added muon L1 prefiring according to latest recipe (with module that combines electron and muon prefiring as seen [here](https://twiki.cern.ch/twiki/bin/view/CMS/L1PrefiringWeightRecipe#Recipe_details_10_6_X_X_26_or_12))

**Tests:**
Ongoing